### PR TITLE
pgsql

### DIFF
--- a/src/commands/new_search.js
+++ b/src/commands/new_search.js
@@ -2,6 +2,7 @@ import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { addSearch } from '../run.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -90,9 +91,16 @@ export const execute = async (interaction) => {
             await interaction.followUp({ content: 'There was an error starting the monitoring.'});
         }
 
+        // schedule immediately
+        try {
+            addSearch(interaction.client, search);
+        } catch (err) {
+            console.error('Live scheduling failed:', err);
+        }
+
         const embed = new EmbedBuilder()
             .setTitle("Search saved!")
-            .setDescription("Monitoring for " + name + " will be started on next restart.")
+            .setDescription("Monitoring for " + name + " is now live!")
             .setColor(0x00FF00);
 
         await interaction.followUp({ embeds: [embed]});


### PR DESCRIPTION
## Summary
- start each search immediately within `addSearch`
- fix embed message to indicate searches are live right away
- simplify interval helpers to rely on global `processedArticleIds`

## Testing
- `node -e "import('./src/run.js').then(()=>console.log('run.js ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/commands/new_search.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "import('./main.js').then(()=>console.log('OK')).catch(e=>{console.error(e);process.exit(1)})"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688d175e099c83278206cc72dacb0ef6