### PR TITLE
Start monitoring immediately after /new_search

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,9 +10,6 @@ dotenv.config();
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 
-//connect the bot to the server
-client.login(process.env.BOT_TOKEN);
-
 //launch the bot
 client.on("ready", async () => {
     console.log(`Logged in as ${client.user.tag}!`);
@@ -28,3 +25,26 @@ client.on('interactionCreate', async (interaction) => {
         console.log('Unknown interaction type');
     }
 });
+
+//connect the bot to the server with retry on session limit
+async function loginWithRetry() {
+    while (true) {
+        try {
+            await client.login(process.env.BOT_TOKEN);
+            break;
+        } catch (err) {
+            const match = err.message.match(/resets at (.*)$/);
+            if (match) {
+                const reset = new Date(match[1]);
+                const wait = Math.max(reset.getTime() - Date.now(), 5000);
+                console.error(`[login] session limit hit; retrying in ${Math.ceil(wait/1000)}s`);
+                await new Promise(r => setTimeout(r, wait));
+            } else {
+                console.error('[login] unexpected error:', err);
+                await new Promise(r => setTimeout(r, 5000));
+            }
+        }
+    }
+}
+
+loginWithRetry();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "fs": "^0.0.1-security",
         "node-fetch": "^3.2.10",
         "dotenv": "^16.4.5",
-        "user-agents": "^1.0.1133"
+        "user-agents": "^1.0.1133",
+        "https-proxy-agent": "^7.0.6"
     }
 }

--- a/src/api/make-request.js
+++ b/src/api/make-request.js
@@ -1,6 +1,14 @@
 import fetch from 'node-fetch';
+import fs from 'fs';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import { authManager } from './auth-manager.js';
+
+function getRandomProxy() {
+    const list = fs.readFileSync('proxies.txt', 'utf-8')
+        .split('\n').map(l => l.trim()).filter(Boolean);
+    return list.length ? list[Math.floor(Math.random() * list.length)] : null;
+}
 
 //general fucntion to make an authorized request
 export const authorizedRequest = async ({
@@ -38,10 +46,12 @@ export const authorizedRequest = async ({
             console.log("making an authed request to " + url);
         }
 
+        const proxy = getRandomProxy();
         const options = {
-            "method": method,
-            "headers": headers,
+            method,
+            headers,
         };
+        if (proxy) options.agent = new HttpsProxyAgent('http://' + proxy);
         if (oldUrl) {
             options.headers["Referer"] = oldUrl;
         }

--- a/src/commands/new_search.js
+++ b/src/commands/new_search.js
@@ -2,6 +2,7 @@ import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { addSearch } from '../run.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -90,9 +91,16 @@ export const execute = async (interaction) => {
             await interaction.followUp({ content: 'There was an error starting the monitoring.'});
         }
 
+        // schedule immediately
+        try {
+            addSearch(interaction.client, search);
+        } catch (err) {
+            console.error('Live scheduling failed:', err);
+        }
+
         const embed = new EmbedBuilder()
             .setTitle("Search saved!")
-            .setDescription("Monitoring for " + name + " will be started on next restart.")
+            .setDescription("Monitoring for " + name + " is now live!")
             .setColor(0x00FF00);
 
         await interaction.followUp({ embeds: [embed]});

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# feste Default-URL, falls ENV leer
+PROXY_LIST_URL="${PROXY_LIST_URL:-https://api.proxyscrape.com/v2/account/datacenter_shared/proxy-list?auth=5aoszl47m6cligu6eq87&type=getproxies&protocol=http&format=txt&status=all&country=all}"
+
+echo "[proxy] lade Liste …"
+if curl -fsSL "$PROXY_LIST_URL" -o proxies.txt && [ -s proxies.txt ]; then
+  echo "[proxy] $(wc -l < proxies.txt) Einträge gespeichert"
+else
+  echo "[proxy] kein Proxy – starte ohne" >&2
+  : > proxies.txt        # leere Datei anlegen
+fi
+
+node main.js  # launch via main entrypoint


### PR DESCRIPTION
## Summary
- provide a default `PROXY_LIST_URL` and ensure an empty `proxies.txt` is created when the download fails
- skip the proxy agent when no proxy is available so requests no longer crash with invalid URLs
- start monitoring immediately after `/new_search` and track processed articles globally to avoid duplicates
- retry Discord login when session limit is hit, waiting until reset instead of crashing

## Testing
- `npm install`
- `node -e "import('./src/api/make-request.js').then(()=>console.log('make-request ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/run.js').then(()=>console.log('run.js ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/commands/new_search.js').then(()=>console.log('new_search ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./main.js').then(()=>console.log('main.js ok')).catch(e=>{console.error(e);process.exit(1)})"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688d175e099c83278206cc72dacb0ef6