### PR TITLE
Start monitoring immediately after /new_search

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,9 +10,6 @@ dotenv.config();
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 
-//connect the bot to the server
-client.login(process.env.BOT_TOKEN);
-
 //launch the bot
 client.on("ready", async () => {
     console.log(`Logged in as ${client.user.tag}!`);
@@ -28,3 +25,26 @@ client.on('interactionCreate', async (interaction) => {
         console.log('Unknown interaction type');
     }
 });
+
+//connect the bot to the server with retry on session limit
+async function loginWithRetry() {
+    while (true) {
+        try {
+            await client.login(process.env.BOT_TOKEN);
+            break;
+        } catch (err) {
+            const match = err.message.match(/resets at (.*)$/);
+            if (match) {
+                const reset = new Date(match[1]);
+                const wait = Math.max(reset.getTime() - Date.now(), 5000);
+                console.error(`[login] session limit hit; retrying in ${Math.ceil(wait/1000)}s`);
+                await new Promise(r => setTimeout(r, wait));
+            } else {
+                console.error('[login] unexpected error:', err);
+                await new Promise(r => setTimeout(r, 5000));
+            }
+        }
+    }
+}
+
+loginWithRetry();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "fs": "^0.0.1-security",
         "node-fetch": "^3.2.10",
         "dotenv": "^16.4.5",
-        "user-agents": "^1.0.1133"
+        "user-agents": "^1.0.1133",
+        "https-proxy-agent": "^7.0.6"
     }
 }

--- a/src/api/make-request.js
+++ b/src/api/make-request.js
@@ -1,6 +1,14 @@
 import fetch from 'node-fetch';
+import fs from 'fs';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import { authManager } from './auth-manager.js';
+
+function getRandomProxy() {
+    const list = fs.readFileSync('proxies.txt', 'utf-8')
+        .split('\n').map(l => l.trim()).filter(Boolean);
+    return list.length ? list[Math.floor(Math.random() * list.length)] : null;
+}
 
 //general fucntion to make an authorized request
 export const authorizedRequest = async ({
@@ -38,10 +46,9 @@ export const authorizedRequest = async ({
             console.log("making an authed request to " + url);
         }
 
-        const options = {
-            "method": method,
-            "headers": headers,
-        };
+        const proxy = getRandomProxy();
+        const options = { method, headers };
+        if (proxy) options.agent = new HttpsProxyAgent('http://' + proxy);
         if (oldUrl) {
             options.headers["Referer"] = oldUrl;
         }

--- a/src/commands/new_search.js
+++ b/src/commands/new_search.js
@@ -2,6 +2,7 @@ import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { addSearch } from '../run.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -90,9 +91,16 @@ export const execute = async (interaction) => {
             await interaction.followUp({ content: 'There was an error starting the monitoring.'});
         }
 
+        // schedule immediately
+        try {
+            addSearch(interaction.client, search);
+        } catch (err) {
+            console.error('Live scheduling failed:', err);
+        }
+
         const embed = new EmbedBuilder()
             .setTitle("Search saved!")
-            .setDescription("Monitoring for " + name + " will be started on next restart.")
+            .setDescription("Monitoring for " + name + " is now live!")
             .setColor(0x00FF00);
 
         await interaction.followUp({ embeds: [embed]});

--- a/src/run.js
+++ b/src/run.js
@@ -2,7 +2,12 @@ import { vintedSearch } from "./bot/search.js";
 import { postArticles } from "./bot/post.js";
 import { fetchCookies } from "./api/fetch-auth.js";
 
-const runSearch = async (client, processedArticleIds, channel) => {
+// Map to keep track of active searches so we don't schedule duplicates
+const activeSearches = new Map();
+// Will hold IDs of articles already processed across all searches
+let processedArticleIds = new Set();
+
+const runSearch = async (client, channel) => {
     try {
         process.stdout.write('.');
         const articles = await vintedSearch(channel, processedArticleIds);
@@ -19,27 +24,34 @@ const runSearch = async (client, processedArticleIds, channel) => {
 };
 
 //run the search and set a timeout to run it again   
-const runInterval = async (client, processedArticleIds, channel) => {
-    await runSearch(client, processedArticleIds, channel);
-    setTimeout(() => runInterval(client, processedArticleIds, channel), channel.frequency*1000);
+const runInterval = async (client, channel) => {
+    await runSearch(client, channel);
+    setTimeout(() => runInterval(client, channel), channel.frequency*1000);
+};
+
+// Attach a new search to the scheduler
+const addSearch = (client, search) => {
+    if (activeSearches.has(search.channelName)) return;
+    activeSearches.set(search.channelName, true);
+
+    (async () => {
+        try {
+            // ersten Poll direkt losschicken, nicht erst nach timeout
+            await runSearch(client, search);
+        } catch (err) {
+            console.error('\nError in initializing articles:', err);
+        }
+        setTimeout(() => { runInterval(client, search); }, 1000);
+    })();
 };
 
 //first, get cookies, then init the article id set, then launch the simmultaneous searches
 export const run = async (client, mySearches) => {
-    let processedArticleIds = new Set();
     await fetchCookies();
- 
-    //stagger start time for searches to avoid too many simmultaneous requests
+
+    //stagger start time for searches to avoid too many simultaneous requests
     mySearches.forEach((channel, index) => {
-        setTimeout(async () => {
-            try {
-                const initArticles = await vintedSearch(channel, processedArticleIds);
-                initArticles.forEach(article => { processedArticleIds.add(article.id); });
-            } catch (err) {
-                console.error('\nError in initializing articles:', err);
-            }
-            setTimeout(() => {runInterval(client, processedArticleIds, channel);}, 1000);
-        }, index * 1000);
+        setTimeout(() => addSearch(client, channel), index * 1000);
     });
 
     //fetch new cookies and clean ProcessedArticleIDs at interval    
@@ -54,3 +66,5 @@ export const run = async (client, mySearches) => {
         }
     }, 1*60*60*1000); //set interval to 1h, after which session could be expired
 };
+
+export { addSearch };

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+MAX_PROXY_FAILS="${MAX_PROXY_FAILS:-5}"     # nach 5 Fehlversuchen kein Sofort-Retry mehr
+LIST_REFRESH_MIN="${LIST_REFRESH_MIN:-180}" # 3-stündiger Refresh, falls Env nicht gesetzt
+PROXY_LIST_URL="${PROXY_LIST_URL:-https://api.proxyscrape.com/v2/account/datacenter_shared/proxy-list?auth=5aoszl47m6cligu6eq87&type=getproxies&protocol=http&format=txt&status=all&country=all}"
+
+proxy_fail_count=0
+download_proxies() {
+  echo "[proxy] lade Liste …"
+  if curl --retry 3 --retry-delay 10 -fsSL "$PROXY_LIST_URL" -o proxies.txt && [ -s proxies.txt ]; then
+    echo "[proxy] $(wc -l < proxies.txt) Einträge gespeichert"
+    proxy_fail_count=0
+  else
+    proxy_fail_count=$((proxy_fail_count+1))
+    echo "[proxy] Download FEHLER ($proxy_fail_count/$MAX_PROXY_FAILS)" >&2
+    : > proxies.txt            # leere Datei, Bot läuft ohne Proxy
+  fi
+}
+download_proxies
+
+(
+  while true; do
+    sleep "$((LIST_REFRESH_MIN*60))"
+    if [ "$proxy_fail_count" -lt "$MAX_PROXY_FAILS" ]; then
+      download_proxies
+    else
+      echo "[proxy] Fehlversuchs-Limit erreicht – überspringe Refresh"
+    fi
+  done
+) &
+
+node main.js
+


### PR DESCRIPTION
## Summary
- provide a default `PROXY_LIST_URL` and ensure an empty `proxies.txt` is created when the download fails
- skip the proxy agent when no proxy is available so requests no longer crash with invalid URLs
- start monitoring immediately after `/new_search` and track processed articles globally to avoid duplicates
- retry Discord login when session limit is hit, waiting until reset instead of crashing
- add proxy download backoff with configurable `MAX_PROXY_FAILS` to limit immediate retries
- run the first poll directly when scheduling a new search to deliver initial results immediately

## Testing
- `npm install`
- `node -e "import('./src/run.js').then(()=>console.log('run.js ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/commands/new_search.js').then(()=>console.log('new_search ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/api/make-request.js').then(()=>console.log('make-request ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./main.js').then(()=>console.log('main.js ok')).catch(e=>{console.error(e);process.exit(1)})"` *(fails: ENETUNREACH)*
- `LIST_REFRESH_MIN=1 timeout 5 bash start.sh` *(fails: curl 403 & ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688d175e099c83278206cc72dacb0ef6