### PR TITLE
Start monitoring immediately after /new_search

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,30 +1,35 @@
-import fs from 'fs';
+process.on('unhandledRejection',(reason)=>console.error('Rejection:',reason));
+
 import dotenv from 'dotenv';
 import { Client, GatewayIntentBits } from 'discord.js';
+import fs from 'fs';
 
-import { run } from "./src/run.js";
-import { registerCommands, handleCommands } from "./src/commands.js";
+import { run } from './src/run.js';
+import { registerCommands, handleCommands } from './src/commands.js';
 
-const mySearches = JSON.parse(fs.readFileSync('./config/channels.json', 'utf8'));
 dotenv.config();
-
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
+const mySearches = JSON.parse(fs.readFileSync('./config/channels.json','utf-8'));
 
-//connect the bot to the server
-client.login(process.env.BOT_TOKEN);
-
-//launch the bot
-client.on("ready", async () => {
-    console.log(`Logged in as ${client.user.tag}!`);
-    registerCommands(client);
-    run(client, mySearches);
+client.on('ready',async()=>{
+  console.log(`Logged in as ${client.user.tag}`);
+  registerCommands(client);
+  run(client,mySearches);
+});
+client.on('interactionCreate',interaction=>{
+  if(interaction.isCommand()) handleCommands(interaction,mySearches);
 });
 
-//listen to buy button clicks
-client.on('interactionCreate', async (interaction) => {
-    if (interaction.isCommand()) {
-        handleCommands(interaction, mySearches);
-    } else {
-        console.log('Unknown interaction type');
+(async function loginWithRetry(){
+  while(true){
+    try {
+      await client.login(process.env.BOT_TOKEN);
+      break;
+    } catch(err){
+      const m = err.message.match(/resets at (.*)$/);
+      const wait = m ? Math.max(new Date(m[1])-Date.now(),5000) : 5000;
+      console.error(`[login] erneut in ${Math.ceil(wait/1000)}s`);
+      await new Promise(r=>setTimeout(r,wait));
     }
-});
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "type": "module",
     "dependencies": {
         "discord.js": "^14.15.2",
-        "fs": "^0.0.1-security",
-        "node-fetch": "^3.2.10",
         "dotenv": "^16.4.5",
-        "user-agents": "^1.0.1133"
+        "undici": "^6.18.1",
+        "valid-url": "^1.0.9"
     }
 }

--- a/src/api/fetch-auth.js
+++ b/src/api/fetch-auth.js
@@ -1,41 +1,35 @@
 import { authorizedRequest } from './make-request.js';
 import { authManager } from './auth-manager.js';
+import { isWebUri } from 'valid-url';
 
-//helper to extract cookie value from the header string
-const extractCookieValue = (header, name) => {
-    const regex = new RegExp(`${name}=([^;]+)`);
-    const match = header.match(regex);
-    return match ? match[1] : null;
-};
+// fetch cookies for the search session with no privileges
+export async function fetchCookies() {
+  const base = process.env.LOGIN_URL || 'https://www.vinted.de';
 
-//fetch cookies for the search session with no privileges
-export const fetchCookies = async () => {
-    try{
-        const headers = await authorizedRequest({
-            method: "HEAD", 
-            url: process.env.BASE_URL+"/how_it_works"
-        });
-    
-        const setCookie = headers.raw()['set-cookie'];
-        const sessionCookiesArray = Array.isArray(setCookie) ? setCookie : (setCookie ? [setCookie] : []);
-        if (!sessionCookiesArray || sessionCookiesArray.length === 0) {
-            throw "Set-Cookie headers not found in the response";
-        }
-        const cookieHasAccessToken = sessionCookiesArray.some(cookie => cookie.includes('access_token_web'));
-        if (cookieHasAccessToken) {
-            console.log('refreshing cookies');
-            //get all set-cookies and extract their values to construct the cookie string
-            const cookieHeader = sessionCookiesArray
-                .map(cookie => cookie.split(';')[0].trim())
-                .join('; ');
-            const cookieObject = {
-                refresh: extractCookieValue(cookieHeader, 'refresh_token_web'),
-                access: extractCookieValue(cookieHeader, 'access_token_web'),
-                vinted: extractCookieValue(cookieHeader, '_vinted_fr_session')
-            };
-            await authManager.setCookies(cookieObject);
-        }
-    } catch (error) {
-        throw "While fetching cookies: " + error;
-    }
-};
+  if (!isWebUri(base)) {
+    console.error('[auth] Ungültige LOGIN_URL:', base);
+    return;
+  }
+
+  const url = base.replace(/\/$/, '') + '/how_it_works';
+
+  try {
+    const res = await authorizedRequest({ method: 'HEAD', url, search: true });
+    const raw = res.headers['set-cookie'] || [];
+    const setCookie = Array.isArray(raw) ? raw : [raw];
+    if (!setCookie.length) throw 'Keine Set-Cookie-Header';
+    const cookies = setCookie
+      .map(c => c.split(';')[0].trim())
+      .filter(Boolean);
+    const cookieObj = {};
+    cookies.forEach(c => {
+      const [k, v] = c.split('=');
+      cookieObj[k] = v;
+    });
+    await authManager.setCookies(cookieObj);
+    console.log('[auth] Cookies aktualisiert');
+  } catch (err) {
+    console.error('[auth] Fehler beim Fetching der Cookies:', err);
+  }
+}
+

--- a/src/api/make-request.js
+++ b/src/api/make-request.js
@@ -1,68 +1,67 @@
-import fetch from 'node-fetch';
-
+import fs from 'fs';
+import { request, ProxyAgent } from 'undici';
 import { authManager } from './auth-manager.js';
 
-//general fucntion to make an authorized request
-export const authorizedRequest = async ({
-    method, 
-    url, 
-    oldUrl = null,
-    search = false,
-    logs = true
-} = {}) => {
-    try {
-        const headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome",
-            "Host": new URL(url).host,
-            "Accept-Encoding": "gzip, deflate, br, zstd",
-            "Connection": "keep-alive",
-            "TE": "trailers",
-            "DNT": 1
-        };
+const UAS = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/124.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) Firefox/127.0',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)'
+];
 
-        if (search) { //cookies from cookies.json
-            const cookies = authManager.getCookies();
-            headers["Cookie"] = Object.entries(cookies)
-                .filter(([, value]) => value)
-                .map(([key, value]) => `${key}=${value}`)
-                .join('; ');
-            headers["Accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
-            headers["Accept-Language"] = "en-US,en;q=0.5";
-            headers["Priority"] = "u=0, i";
-            headers["Sec-Fetch-Dest"] = "document";
-            headers["Sec-Fetch-Mode"] = "navigate";
-            headers["Sec-Fetch-Site"] = "cross-site";
-            headers["Upgrade-Insecure-Requests"] = "1";
-        }
-        if (logs) {
-            console.log("making an authed request to " + url);
-        }
+let proxyList = [], stickyProxy = null, stickyUntil = 0;
 
-        const options = {
-            "method": method,
-            "headers": headers,
-        };
-        if (oldUrl) {
-            options.headers["Referer"] = oldUrl;
-        }
+function reloadProxies() {
+  try {
+    proxyList = fs.readFileSync('proxies.txt','utf-8')
+                  .split('\n').map(l=>l.trim()).filter(Boolean);
+  } catch {
+    proxyList = [];
+  }
+}
+reloadProxies();
+fs.watchFile('proxies.txt',{interval:60_000},reloadProxies);
 
-        let response = await fetch(url, options);
+function getProxy() {
+  const now = Date.now();
+  if (stickyProxy && now < stickyUntil) return stickyProxy;
+  if (!proxyList.length) return null;
+  stickyProxy = proxyList[Math.random()*proxyList.length|0];
+  stickyUntil = now + 60_000;
+  return stickyProxy;
+}
 
-        while ([301, 302, 303, 307, 308].includes(response.status)) {
-            const newUrl = response.headers.get('Location');
-            console.log(`redirected to ${newUrl}`);
-            response = await fetch(newUrl, options);
-        }
-        if (!response.ok) {
-            throw `HTTP status: ${response.status}`;
-        }
-        if (response.headers.get('Content-Type')?.includes('text/html')) {
-            console.warn("Response is HTML")
-            return response.headers;
-        }
-
-        return await response.json();
-    } catch (error) {
-        throw "While making request: " + error;
+export const authorizedRequest = async ({method,url,oldUrl=null,search=false,logs=true}={})=>{
+  for (let attempt=0; attempt<5; ++attempt) {
+    const headers = {
+      'User-Agent': UAS[attempt%UAS.length],
+      'Host': new URL(url).host,
+      'Accept-Encoding':'gzip,deflate,br',
+      'Connection':'close',
+      'DNT':1
+    };
+    if (search) {
+      const cookies = authManager.getCookies();
+      headers['Cookie'] = Object.entries(cookies)
+        .filter(([,v])=>v)
+        .map(([k,v])=>`${k}=${v}`).join('; ');
+      headers['Accept']='application/json';
     }
+    if (oldUrl) headers['Referer']=oldUrl;
+
+    const proxy = getProxy();
+    const dispatcher = proxy ? new ProxyAgent('http://'+proxy) : undefined;
+
+    let res = await request(url,{method,headers,dispatcher});
+    while ([301,302,307,308].includes(res.statusCode)) {
+      url = res.headers.location;
+      res = await request(url,{method,headers,dispatcher});
+    }
+    if (res.statusCode>=200 && res.statusCode<300) {
+      return res;
+    }
+    console.warn(`[req] Status ${res.statusCode}, Retry #${attempt+1}`);
+    stickyUntil = 0;
+  }
+  throw 'Kein Proxy hat funktioniert';
 };
+

--- a/src/bot/search.js
+++ b/src/bot/search.js
@@ -21,7 +21,14 @@ export const vintedSearch = async (channel, processedArticleIds) => {
         color_ids: ids.colour,
         material_ids: ids.material,
     }).toString();
-    const responseData = await authorizedRequest({method: "GET", url: apiUrl.href, oldUrl: channel.url, search: true, logs: false});
+    let res;
+    try {
+        res = await authorizedRequest({method: "GET", url: apiUrl.href, oldUrl: channel.url, search: true, logs: false});
+    } catch (err) {
+        console.error('[search] Proxy-Request fehlgeschlagen:', err);
+        return [];
+    }
+    const responseData = await res.body.json();
     const articles = selectNewArticles(responseData, processedArticleIds, channel);
     return articles;
 };

--- a/src/commands/new_search.js
+++ b/src/commands/new_search.js
@@ -2,6 +2,7 @@ import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { addSearch } from '../run.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -90,9 +91,16 @@ export const execute = async (interaction) => {
             await interaction.followUp({ content: 'There was an error starting the monitoring.'});
         }
 
+        // schedule immediately
+        try {
+            addSearch(interaction.client, search);
+        } catch (err) {
+            console.error('Live scheduling failed:', err);
+        }
+
         const embed = new EmbedBuilder()
             .setTitle("Search saved!")
-            .setDescription("Monitoring for " + name + " will be started on next restart.")
+            .setDescription("Monitoring for " + name + " is now live!")
             .setColor(0x00FF00);
 
         await interaction.followUp({ embeds: [embed]});

--- a/src/run.js
+++ b/src/run.js
@@ -2,7 +2,12 @@ import { vintedSearch } from "./bot/search.js";
 import { postArticles } from "./bot/post.js";
 import { fetchCookies } from "./api/fetch-auth.js";
 
-const runSearch = async (client, processedArticleIds, channel) => {
+// Map to keep track of active searches so we don't schedule duplicates
+const activeSearches = new Map();
+// Will hold IDs of articles already processed across all searches
+let processedArticleIds = new Set();
+
+const runSearch = async (client, channel) => {
     try {
         process.stdout.write('.');
         const articles = await vintedSearch(channel, processedArticleIds);
@@ -19,27 +24,36 @@ const runSearch = async (client, processedArticleIds, channel) => {
 };
 
 //run the search and set a timeout to run it again   
-const runInterval = async (client, processedArticleIds, channel) => {
-    await runSearch(client, processedArticleIds, channel);
-    setTimeout(() => runInterval(client, processedArticleIds, channel), channel.frequency*1000);
+const runInterval = async (client, channel) => {
+    await runSearch(client, channel);
+    const delay = channel.frequency * 1000 * (0.8 + Math.random() * 0.4);
+    setTimeout(() => runInterval(client, channel), delay);
+};
+
+// Attach a new search to the scheduler
+const addSearch = (client, search) => {
+    if (activeSearches.has(search.channelName)) return;
+    activeSearches.set(search.channelName, true);
+
+    (async () => {
+        try {
+            // ersten Poll direkt losschicken, nicht erst nach timeout
+            await runSearch(client, search);
+        } catch (err) {
+            console.error('\nError in initializing articles:', err);
+        }
+        setTimeout(() => { runInterval(client, search); }, 1000);
+    })();
 };
 
 //first, get cookies, then init the article id set, then launch the simmultaneous searches
 export const run = async (client, mySearches) => {
-    let processedArticleIds = new Set();
+    processedArticleIds = new Set();
     await fetchCookies();
- 
-    //stagger start time for searches to avoid too many simmultaneous requests
+
+    //stagger start time for searches to avoid too many simultaneous requests
     mySearches.forEach((channel, index) => {
-        setTimeout(async () => {
-            try {
-                const initArticles = await vintedSearch(channel, processedArticleIds);
-                initArticles.forEach(article => { processedArticleIds.add(article.id); });
-            } catch (err) {
-                console.error('\nError in initializing articles:', err);
-            }
-            setTimeout(() => {runInterval(client, processedArticleIds, channel);}, 1000);
-        }, index * 1000);
+        setTimeout(() => addSearch(client, channel), index * 1000);
     });
 
     //fetch new cookies and clean ProcessedArticleIDs at interval    
@@ -54,3 +68,5 @@ export const run = async (client, mySearches) => {
         }
     }, 1*60*60*1000); //set interval to 1h, after which session could be expired
 };
+
+export { addSearch };

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+# — Konfiguration —
+PS_API_KEY="${PS_API_KEY:-}"
+SERVICE_ID="${SERVICE_ID:-}"
+MAX_PROXY_FAILS="${MAX_PROXY_FAILS:-5}"
+LIST_REFRESH_MIN="${LIST_REFRESH_MIN:-180}"
+PROXY_LIST_URL="${PROXY_LIST_URL:-https://api.proxyscrape.com/v2/account/datacenter_shared/proxy-list?auth=${PS_API_KEY}&type=getproxies&protocol=http&format=txt&status=all&country=all}"
+WHITELIST_SLEEP="${WHITELIST_SLEEP:-60}"
+
+# — Railway-Whitelist —
+if [ -n "$PS_API_KEY" ] && [ -n "$SERVICE_ID" ]; then
+  MY_IP=$(curl -fsS https://api64.ipify.org)
+  curl -fsSL "https://api.proxyscrape.com/v2/account/datacenter_shared/whitelist" \
+       --data-urlencode "auth=${PS_API_KEY}" \
+       --data-urlencode "service=${SERVICE_ID}" \
+       --data-urlencode "ip[]=${MY_IP}"
+  echo "[proxy] IP $MY_IP whitelisted – warte ${WHITELIST_SLEEP}s"
+  sleep "$WHITELIST_SLEEP"
+else
+  echo "[proxy] WARN: PS_API_KEY oder SERVICE_ID fehlt – überspringe Whitelist" >&2
+fi
+
+# — Proxy-Download mit Backoff —
+proxy_fail_count=0
+_download_proxies() {
+  echo "[proxy] lade Liste …"
+  if [ -z "$PROXY_LIST_URL" ]; then
+    echo "[proxy] keine PROXY_LIST_URL – überspringe Download" >&2
+    : > proxies.txt
+    return
+  fi
+  if curl --retry 3 --retry-delay 10 -fsSL "$PROXY_LIST_URL" -o proxies.txt && [ -s proxies.txt ]; then
+    echo "[proxy] $(wc -l < proxies.txt) Proxies gespeichert"
+    proxy_fail_count=0
+  else
+    proxy_fail_count=$((proxy_fail_count+1))
+    echo "[proxy] Download FEHLER ($proxy_fail_count/$MAX_PROXY_FAILS)" >&2
+    : > proxies.txt
+  fi
+}
+_download_proxies
+
+(
+  while true; do
+    sleep $((LIST_REFRESH_MIN*60))
+    if [ "$proxy_fail_count" -lt "$MAX_PROXY_FAILS" ]; then
+      _download_proxies
+    else
+      echo "[proxy] Fehlversuchs-Limit erreicht – überspringe Refresh"
+    fi
+  done
+) &
+
+# — Bot starten —
+node main.js


### PR DESCRIPTION
## Summary
- Hardened proxy setup: optional credentials skip whitelisting, default proxy list is used when available, and downloads back off after repeated failures
- Removed the unused `https-proxy-agent` package and rely solely on undici’s `ProxyAgent`
- Prevented crashes in `vintedSearch` by catching failed proxy requests

## Testing
- `npm install`
- `node -e "import('./src/run.js').then(()=>console.log('run.js ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/commands/new_search.js').then(()=>console.log('new_search ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/api/make-request.js').then(()=>console.log('make-request ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./src/api/fetch-auth.js').then(()=>console.log('fetch-auth ok')).catch(e=>{console.error(e);process.exit(1)})"`
- `node -e "import('./main.js').then(()=>console.log('main ok')).catch(e=>{console.error(e);process.exit(1)})"` *(fails: login retries due to missing Discord access)*
- `PS_API_KEY= SERVICE_ID= PROXY_LIST_URL= timeout 5 bash start.sh` *(warns about missing credentials and falls back to empty proxy list)*

------
https://chatgpt.com/codex/tasks/task_e_688d175e099c83278206cc72dacb0ef6