### PR TITLE
Fix vinted url, proxy, and health logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
         "discord.js": "^14.15.2",
         "dotenv": "^16.4.5",
         "tough-cookie": "^4.1.4",
-        "valid-url": "^1.0.9"
+        "valid-url": "^1.0.9",
+        "http-cookie-agent": "^6.0.5",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.4"
     }
 }

--- a/src/bot/search.js
+++ b/src/bot/search.js
@@ -1,4 +1,4 @@
-import { getHttp, rotateProxy } from "../net/http.js";
+import { getHttp, rotateProxy, isProxyReallyBad } from "../net/http.js";
 import { handleParams } from "./handle-params.js";
 
 //send the authenticated request
@@ -37,8 +37,9 @@ export const vintedSearch = async (channel, processedArticleIds) => {
           if (!ct.includes('application/json')) throw new Error(`Non-JSON: ${ct}`);
           return selectNewArticles(res.data, processedArticleIds, channel);
       } catch (e) {
-          console.warn('[search] fail on proxy', proxy, e.message || e);
-          rotateProxy(proxy);
+          const status = e?.response?.status;
+          console.warn('[search] fail on proxy', proxy, status ? `status ${status}` : (e.message || e));
+          if (isProxyReallyBad(e)) rotateProxy(proxy);
       }
 
       try {
@@ -55,8 +56,9 @@ export const vintedSearch = async (channel, processedArticleIds) => {
           if (!ct.includes('application/json')) throw new Error(`Non-JSON: ${ct}`);
           return selectNewArticles(res.data, processedArticleIds, channel);
       } catch (e2) {
-          console.warn('[search] retry failed on proxy', proxy, e2.message || e2);
-          rotateProxy(proxy);
+          const status = e2?.response?.status;
+          console.warn('[search] retry failed on proxy', proxy, status ? `status ${status}` : (e2.message || e2));
+          if (isProxyReallyBad(e2)) rotateProxy(proxy);
           return [];
       }
 };

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -1,31 +1,49 @@
 import axios from 'axios';
-import { wrapper } from 'axios-cookiejar-support';
 import { CookieJar } from 'tough-cookie';
+import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http';
+import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getProxy, markBadInPool } from './proxyHealth.js';
 
 const clientsByProxy = new Map();
 let CURRENT_PROXY = null;
 
+function buildAgents(proxyStr) {
+  const jar = new CookieJar();
+  const proxyUrl = proxyStr ? `http://${proxyStr}` : null;
+  const httpAgent = new HttpCookieAgent({
+    cookies: { jar },
+    keepAlive: true,
+    agent: proxyUrl ? new HttpProxyAgent(proxyUrl) : undefined,
+  });
+  const httpsAgent = new HttpsCookieAgent({
+    cookies: { jar },
+    keepAlive: true,
+    agent: proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined,
+  });
+  return { httpAgent, httpsAgent };
+}
+
 function createClient(proxyStr) {
   const existing = clientsByProxy.get(proxyStr);
   if (existing) return existing;
 
-  const [host, portStr] = proxyStr.split(':');
-  const port = Number(portStr);
-  const http = wrapper(
-    axios.create({
-      jar: new CookieJar(),
-      withCredentials: true,
-      maxRedirects: 5,
-      timeout: 15000,
-      proxy: { protocol: 'http', host, port },
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      },
-    })
-  );
+  const { httpAgent, httpsAgent } = buildAgents(proxyStr);
+  const http = axios.create({
+    proxy: false,
+    httpAgent,
+    httpsAgent,
+    withCredentials: true,
+    maxRedirects: 5,
+    timeout: 15000,
+    headers: {
+      'user-agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+      accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'accept-language': 'de-DE,de;q=0.9,en;q=0.8',
+      'upgrade-insecure-requests': '1',
+    },
+  });
   const client = { http };
   clientsByProxy.set(proxyStr, client);
   return client;
@@ -35,14 +53,7 @@ export function getHttp() {
   if (!CURRENT_PROXY) CURRENT_PROXY = getProxy();
   if (!CURRENT_PROXY) {
     if (process.env.ALLOW_DIRECT === '1') {
-      const http = wrapper(
-        axios.create({
-          withCredentials: true,
-          maxRedirects: 5,
-          timeout: 15000,
-          proxy: false,
-        })
-      );
+      const { http } = createClient('');
       return { http, proxy: 'DIRECT' };
     }
     throw new Error('No healthy proxies available');
@@ -54,11 +65,21 @@ export function getHttp() {
 
 export function rotateProxy(badProxy) {
   if (badProxy && clientsByProxy.has(badProxy)) clientsByProxy.delete(badProxy);
-  if (badProxy) markBadInPool(badProxy);
+  if (badProxy && badProxy !== 'DIRECT') markBadInPool(badProxy);
   CURRENT_PROXY = getProxy();
 }
 
 export async function initProxyPool() {
   return (await import('./proxyHealth.js')).initProxyPool();
+}
+
+export function isProxyReallyBad(err) {
+  if (!err) return false;
+  const code = err.code || '';
+  const status = err.response?.status;
+
+  if (['ECONNRESET','ETIMEDOUT','ENETUNREACH','ECONNREFUSED','EHOSTUNREACH'].includes(code)) return true;
+  if (status === 407) return true;
+  return false;
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -9,6 +9,10 @@ const activeSearches = new Map();
 // Will hold IDs of articles already processed across all searches
 let processedArticleIds = new Set();
 
+const rawBase = process.env.VINTED_BASE_URL || 'https://www.vinted.de';
+const baseNoSemi = rawBase.replace(/;+$/, '');
+const HOME_URL = new URL('/', new URL(baseNoSemi)).toString();
+
 const runSearch = async (client, channel) => {
     try {
         process.stdout.write('.');
@@ -87,7 +91,7 @@ export const run = async (client, mySearches) => {
     try {
         const { http } = getHttp();
         try {
-            await http.get(process.env.VINTED_BASE_URL || 'https://www.vinted.de/');
+            await http.get(HOME_URL);
         } catch (err) {
             console.error('[run] initial cookie fetch failed:', err);
         }
@@ -104,7 +108,7 @@ export const run = async (client, mySearches) => {
     setInterval(async () => {
         try {
             const { http } = getHttp();
-            await http.get(process.env.VINTED_BASE_URL || 'https://www.vinted.de/');
+            await http.get(HOME_URL);
             console.log('reducing processed articles size');
             const halfSize = Math.floor(processedArticleIds.size / 2);
             processedArticleIds = new Set([...processedArticleIds].slice(halfSize));


### PR DESCRIPTION
Fixes 400 errors and proxy pool exhaustion by correcting Vinted URL, enabling proper HTTPS proxy tunneling, and refining proxy health checks.

The initial cookie fetch to Vinted failed due to a trailing semicolon in the URL and incorrect HTTPS tunneling through the proxy, leading to Cloudflare 400 errors. These 400 errors were then misinterpreted by the health logic as proxy failures, causing the proxy pool to be prematurely drained and subsequent "no healthy proxies available" issues. This PR resolves these root causes.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9bdf80-405c-4574-bd26-5e7a0515a4aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f9bdf80-405c-4574-bd26-5e7a0515a4aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

