### PR TITLE
Fix default price bucket parsing for fanout policy

### DIFF
--- a/src/rules/policy.js
+++ b/src/rules/policy.js
@@ -13,9 +13,12 @@ import path from 'path';
 // }
 
 function parseBucketsCsv(csv) {
-  const nums = String(csv || '')
+  const parts = String(csv || '')
     .split(/[,|;\s]+/)
-    .map(s => Number(s.trim()))
+    .map(s => s.trim())
+    .filter(Boolean);
+  const nums = parts
+    .map(s => Number(s))
     .filter(n => Number.isFinite(n));
   return new Set(nums);
 }

--- a/test/fanout.test.js
+++ b/test/fanout.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { dedupeKeyForChannel } from '../src/utils/dedupe.js';
-import { buildParentGroups } from '../src/rules/parenting.js';
+import { buildParentGroups, buildAutoPriceFamilies } from '../src/rules/parenting.js';
 
 test('dedupe is per-channel scoped', () => {
   const a = { channelId: 'A', channelName: 'parent', url: 'https://www.vinted.de/catalog?brand_ids[]=1&catalog[]=123' };
@@ -19,5 +19,33 @@ test('buildParentGroups creates family with children', () => {
   const found = fams.find(f => f.parent.channelName === 'p-all' || f.children.some(c => c.rule.channelName === 'p-cheap'));
   assert.ok(found);
   assert.ok((found.children || []).length > 0);
+});
+
+test('auto price families keep children when no buckets configured', (t) => {
+  const prevDefault = process.env.FAMILY_PRICE_BUCKETS_DEFAULT;
+  const prevByBrand = process.env.FAMILY_PRICE_BUCKETS_BY_BRAND;
+  const prevAllowed = process.env.FAMILY_ALLOWED_BRAND_IDS;
+  delete process.env.FAMILY_PRICE_BUCKETS_DEFAULT;
+  delete process.env.FAMILY_PRICE_BUCKETS_BY_BRAND;
+  delete process.env.FAMILY_ALLOWED_BRAND_IDS;
+  t.after(() => {
+    if (prevDefault === undefined) delete process.env.FAMILY_PRICE_BUCKETS_DEFAULT;
+    else process.env.FAMILY_PRICE_BUCKETS_DEFAULT = prevDefault;
+    if (prevByBrand === undefined) delete process.env.FAMILY_PRICE_BUCKETS_BY_BRAND;
+    else process.env.FAMILY_PRICE_BUCKETS_BY_BRAND = prevByBrand;
+    if (prevAllowed === undefined) delete process.env.FAMILY_ALLOWED_BRAND_IDS;
+    else process.env.FAMILY_ALLOWED_BRAND_IDS = prevAllowed;
+  });
+  const rules = [
+    { channelName: 'nike-all', url: 'https://www.vinted.de/catalog?order=newest_first&search_text=Nike' },
+    { channelName: 'nike-all-10€', url: 'https://www.vinted.de/catalog?order=newest_first&price_to=10&search_text=Nike' },
+    { channelName: 'nike-all-15€', url: 'https://www.vinted.de/catalog?order=newest_first&price_to=15&search_text=Nike' },
+    { channelName: 'nike-all-20€', url: 'https://www.vinted.de/catalog?order=newest_first&price_to=20&search_text=Nike' },
+    { channelName: 'nike-all-30€', url: 'https://www.vinted.de/catalog?order=newest_first&price_to=30&search_text=Nike' },
+  ];
+  const fams = buildAutoPriceFamilies(rules);
+  const fam = fams.find(f => f.parent?.channelName === 'nike-all');
+  assert.ok(fam);
+  assert.equal(fam.children.length, 4);
 });
 


### PR DESCRIPTION
## Summary
- ignore empty entries while parsing family price bucket configuration so the default no-env setup no longer produces a bogus `0` bucket that strips all children
- add a regression test covering auto price families to ensure children remain when no price buckets are configured

## Testing
- node --test test/fanout.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d27750217483279374ac70bbbf5bc8